### PR TITLE
Remove unused "fraction" requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,5 @@ setup(name="moarchiving",
       keywords=["optimization", "multi-objective",],
       packages=["moarchiving"],
       # install_requires=["bisect"],
-      extras_require={
-            "arbitrary-precision": ["fraction"],
-      },
       package_data={'': ['LICENSE', ]},  # i.e. moarchiving/LICENSE
       )


### PR DESCRIPTION
This package uses the `fractions` module, which is in the Python standard library.  There seems to be no reason to pull in this library.

I considered keeping an empty `arbitrary-precision` extra around for compatibility, but I don't think there's any point since neither of the reverse-dependencies found on
https://www.wheelodex.org/projects/moarchiving/rdepends/ appear to use that extra.

See https://bugs.debian.org/1075905.