### PR TITLE
fix: add prune function for moarchiving 3D, fix 4D pruning

### DIFF
--- a/moarchiving/moarchiving3obj.py
+++ b/moarchiving/moarchiving3obj.py
@@ -86,6 +86,8 @@ class MOArchive3obj(MOArchiveParent):
 
         self._removed = []
         self.preprocessing()
+        if self.reference_point is None:
+            self.prune()
         hv = self._set_HV()
         self._length = len(list(self))
         if hv is not None and hv > 0:
@@ -463,6 +465,29 @@ class MOArchive3obj(MOArchiveParent):
             p = p.next[2]
 
         return self.hypervolume_final_float_type(volume)
+
+    def prune(self):
+        """Prune the archive when the reference point is not given.
+        Otherwise the archive is pruned in the compute_hypervolume method."""
+
+        p = self.head
+
+        restart_list_y(self.head)
+        p = p.next[2].next[2]
+        stop = self.head.prev[2]
+
+        while p != stop:
+            if p.ndomr < 1:
+                p.cnext[0] = p.closest[0]
+                p.cnext[1] = p.closest[1]
+
+                p.cnext[0].cnext[1] = p
+                p.cnext[1].cnext[0] = p
+            else:
+                remove_from_z(p, archive_dim=self.n_obj)
+
+            p = p.next[2]
+
 
     def preprocessing(self):
         """ Preprocessing step to determine the closest points in x and y directions,

--- a/moarchiving/moarchiving4obj.py
+++ b/moarchiving/moarchiving4obj.py
@@ -299,8 +299,7 @@ class MOArchive4obj(MOArchiveParent):
         while current != stop:
             dominated = False
             for node in non_dominated_points:
-                if node != current and all(node.x[i] <= current.x[i] for i in range(3)) and any(
-                        node.x[i] < current.x[i] for i in range(3)):
+                if node != current and all(node.x[i] <= current.x[i] for i in range(3)):
                     dominated = True
                     break
             if dominated:

--- a/moarchiving/tests/test_moarchiving3obj.py
+++ b/moarchiving/tests/test_moarchiving3obj.py
@@ -153,6 +153,19 @@ class TestMOArchiving3obj(unittest.TestCase):
         self.assertFalse(moa.dominates([2, 5, 4]))
         self.assertFalse(moa.dominates([5, 1, 3]))
 
+    def test_prune(self):
+        """ Test the prune function """
+        ref_point = [6, 6, 6]
+        points = [[1, 2, 3], [2, 1, 4], [3, 3, 3], [1, 2, 3]]
+        moa_ref = MOArchive3obj(points, ref_point)
+        moa_no_ref = MOArchive3obj(points)
+
+        self.assertEqual(len(list(moa_ref)), 2)
+        self.assertEqual(len(list(moa_no_ref)), 2)
+
+        self.assertEqual(list_to_set(list(moa_ref)), {(1, 2, 3), (2, 1, 4)})
+        self.assertEqual(list_to_set(list(moa_no_ref)), {(1, 2, 3), (2, 1, 4)})
+
     def test_dominators(self):
         """ Test the dominators function """
         ref_point = [6, 6, 6]

--- a/moarchiving/tests/test_moarchiving4obj.py
+++ b/moarchiving/tests/test_moarchiving4obj.py
@@ -148,6 +148,19 @@ class TestMOArchiving4obj(unittest.TestCase):
         self.assertFalse(moa.dominates([5, 3, 3, 2]))
         self.assertFalse(moa.dominates([0, 5, 5, 5]))
 
+    def test_prune(self):
+        """ Test the prune function """
+        ref_point = [6, 6, 6, 6]
+        points = [[1, 2, 3, 4], [5, 2, 1, 4], [4, 4, 4, 4], [1, 2, 3, 4]]
+        moa_ref = MOArchive4obj(points, ref_point)
+        moa_no_ref = MOArchive4obj(points)
+
+        self.assertEqual(len(list(moa_ref)), 2)
+        self.assertEqual(len(list(moa_no_ref)), 2)
+
+        self.assertEqual(list_to_set(list(moa_ref)), {(1, 2, 3, 4), (5, 2, 1, 4)})
+        self.assertEqual(list_to_set(list(moa_no_ref)), {(1, 2, 3, 4), (5, 2, 1, 4)})
+
     def test_dominators(self):
         """ test the dominators function """
         moa = get_small_test_archive()


### PR DESCRIPTION
This PR fixes the problems from issue #26. It adds a new `prune` method for 3D moarchiving class which removes the dominated points from the archive when reference point is None. When reference point is not None this happens in `compute_hypervolume`. Additionally it fixes a problem of having duplicated points in 4D archive and adds unit tests. 